### PR TITLE
build(#10): update workflow for Node.js 24

### DIFF
--- a/.github/workflows/quarto-publish.yml
+++ b/.github/workflows/quarto-publish.yml
@@ -14,7 +14,7 @@ jobs:
     
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2
@@ -23,10 +23,10 @@ jobs:
         uses: quarto-dev/quarto-actions/render@v2
       
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: _site
       
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
Your commits explain the `who`, `what`, `where` and `when` of these changes. Your code shows the `how`. You do not need to reiterate this. This PR should complete the big picture by telling the `why`.

### Justification

GitHub changes from Node.js 20 to 24 will prevent many actions from running  after June 2, 2026. This PR updates the actions in the ghpages deployment yml to their latest versions

fixes #10 

### Reviewer instructions:

Not sure this can be tested. The action will only deploy on pushes to main
