### PR TITLE
chore(#29): removal of merge conflict syntax

### DIFF
--- a/user_guides/quarto_site/part1/03-installation-and-running.qmd
+++ b/user_guides/quarto_site/part1/03-installation-and-running.qmd
@@ -1,12 +1,6 @@
 # Installation and Running {#sec-installation}
 
-<<<<<<< main
-** THIS SECTION IS OUT OF DATE **
-
-## **2.1 How to check out and install the code**
-=======
 ## How to check out and install the code** {#sec-checkout-install}
->>>>>>> bug/i14-dynamic-figure-indexing
 
 ::: callout-important
 AR note: as of March 2026 this section is no longer current as we moved to GitHub.
@@ -120,11 +114,7 @@ Atlantis input files come in six file formats:
 All files except for NC files can be opened and edited using any basic text editing software (such as TextPad or NotePad). Until recently this was the usual way to setup and modify model parameters. However, some PRM files are thousands of lines long, which means that hand editing can be tedious and a source of error. New R-based tools are currently under development to help users visualise and modify parameter files in a more streamlined way (see below)
 
 ::: callout-caution
-<<<<<<< main
-**PC, Mac and Unix computers use different syntax to indicate line end.** This means that should you receive files from someone using a different operating system, the PRM files will have to be converted to match your local operating system. In Linux this can be done using the ['flip' software](https://atlantis-ecosystem-model.github.io/atlantis-wiki/file-formats.html). If you only have a few files this can be done by simply opening the parameter files in a text editor (e.g. TextPad in Windows or TextWrangler in Mac) and saving them in a format suitable for your operating system (see menu "File Format"). More info on line terminators can be found on the wiki [here](http://en.wikipedia.org/wiki/Newline) or by searching in your favourite search engine.
-=======
-**PC, Mac, and Unix computers use different syntax to indicate line end.** This means that should you receive files from someone using a different operating system, the PRM files will have to be converted to match your local operating system. In Linux this can be done using the ['flip' software](https://confluence.csiro.au/display/Atlantis/File+Formats). If you only have a few files this can be done by simply opening the parameter files in a text editor (e.g. TextPad in Windows or TextWrangler in Mac) and saving them in a format suitable for your operating system (see menu "File Format"). More info on line terminators can be found on the wiki [here](http://en.wikipedia.org/wiki/Newline) or by searching in your favourite search engine.
->>>>>>> bug/i14-dynamic-figure-indexing
+**PC, Mac, and Unix computers use different syntax to indicate line end.** This means that should you receive files from someone using a different operating system, the PRM files will have to be converted to match your local operating system. In Linux this can be done using the ['flip' software](https://atlantis-ecosystem-model.github.io/atlantis-wiki/file-formats.html). If you only have a few files this can be done by simply opening the parameter files in a text editor (e.g. TextPad in Windows or TextWrangler in Mac) and saving them in a format suitable for your operating system (see menu "File Format"). More info on line terminators can be found on the wiki [here](http://en.wikipedia.org/wiki/Newline) or by searching in your favourite search engine.
 
 ![](media/image60_1.png){width="5.9in" height="3.8in"}
 :::

--- a/user_guides/quarto_site/part1/10-primary-producer-processes.qmd
+++ b/user_guides/quarto_site/part1/10-primary-producer-processes.qmd
@@ -177,11 +177,7 @@ where *mS_MA* is the algal mortality rate (day^-1^) due to abrasion by bottom st
 Lysis represents cell leakage and is inversely related to nutrient concentration, whereas linear mortality is just a constant mortality term. PPBIM only had the linear mortality, but ERSEM also included lysis, and both options are included in Atlantis. The users have an option to use either or both, depending on the mortality parameter values set.
 :::
 
-<<<<<<< main
-Finally, the extra mortality will also include any **optional acidification induced mortality**, described in details [here](https://atlantis-ecosystem-model.github.io/atlantis-wiki/posts/handling-effects-of-acidification.html) and [here](https://atlantis-ecosystem-model.github.io/atlantis-wiki/posts/acidification-induced-mortality.html) and in Chapter 13. The acidification mortality is only included if the model explicitly includes pH effects ([flagmodelpH]{style="color: orange;"}=1) and primary producers are identified as pH sensitive ([flagpHsensitive_XXX]{style="color: orange;"}=1).
-=======
-Finally, the extra mortality will also include any **optional acidification induced mortality**, described in details [here](https://confluence.csiro.au/pages/viewpage.action?spaceKey=Atlantis&postingDay=2012%2F10%2F19&title=Handling+effects+of+acidification) and [here](https://confluence.csiro.au/pages/viewpage.action?spaceKey=Atlantis&postingDay=2015%2F5%2F14&title=Acidification+induced+mortality) and in @sec-environmental-factors. The acidification mortality is only included if the model explicitly includes pH effects ([flagmodelpH]{style="color: orange;"}=1) and primary producers are identified as pH sensitive ([flagpHsensitive_XXX]{style="color: orange;"}=1).
->>>>>>> bug/i14-dynamic-figure-indexing
+Finally, the extra mortality will also include any **optional acidification induced mortality**, described in details [here](https://atlantis-ecosystem-model.github.io/atlantis-wiki/posts/handling-effects-of-acidification.html) and [here](https://atlantis-ecosystem-model.github.io/atlantis-wiki/posts/acidification-induced-mortality.html) and in @sec-environmental-factors. The acidification mortality is only included if the model explicitly includes pH effects ([flagmodelpH]{style="color: orange;"}=1) and primary producers are identified as pH sensitive ([flagpHsensitive_XXX]{style="color: orange;"}=1).
 
 Primary producer mortality is handled by *Primary_Production()* in **atprocess.c** and *Phytoplankton\_ Process()* in **atGroupProcess.c** routines.
 


### PR DESCRIPTION

### Justification

Book was rendering with merge conflict syntax from a previous PR that was not fully completed. The book now renders affected pages without issues

Be sure to link to the issue below:

fixes #29 

### Reviewer instructions:

Switch to branch `chore/i29-unresolved-merge-conflicts` and then render the book locally.
View pages `03-installation-and-running.qmd` and `10-primary-producer-processes.qmd` and ensure issues are resolved

